### PR TITLE
fix: nodes maintain ordering while opening or closing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schyma",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "JSON Schemas Visualizer React component",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/utils/dagreUtils.ts
+++ b/src/utils/dagreUtils.ts
@@ -16,7 +16,9 @@ export const getLayoutedElements = (nodes: Node[], edges: Edge[], direction = 'L
     dagreGraph.setEdge(edge.source, edge.target)
   })
 
-  dagre.layout(dagreGraph)
+  dagre.layout(dagreGraph, {
+    disableOptimalOrderHeuristic: true,
+  })
 
   nodes.forEach((node: Node) => {
     const nodeId = node.id


### PR DESCRIPTION
context: https://github.com/AceTheCreator/schyma/pull/5#issuecomment-2506366076

BEFORE (notice how the ordering of the node changes every time I click):
https://github.com/user-attachments/assets/ec64b027-b2fe-460d-9015-7e0c917e0c06


AFTER (the ordering doesnt change anymore):
https://github.com/user-attachments/assets/572dc5d3-f7fc-4c11-a612-9b835c68b1bc